### PR TITLE
Fix longjmp and printf of hex values

### DIFF
--- a/newlib/libc/machine/riscv/setjmp.S
+++ b/newlib/libc/machine/riscv/setjmp.S
@@ -57,6 +57,7 @@ setjmp:
 /* volatile void longjmp (jmp_buf, int);  */
   .globl  longjmp
   .type   longjmp, @function
+  .align 3
 longjmp:
 	REG_L ra,  0*SZREG(a0)
 	REG_L s0,  1*SZREG(a0)
@@ -72,6 +73,21 @@ longjmp:
 	REG_L s9, 10*SZREG(a0)
 	REG_L s10,11*SZREG(a0)
 	REG_L s11,12*SZREG(a0)
+
+# make sure we blow away any tags on the stack
+    addi sp, sp, -2 * SZREG
+    REG_S s0, 0(sp)
+    REG_S s1, SZREG(sp)
+    mv s0, sp
+    addi s0, s0, 2 * SZREG
+    REG_L s1, 13*SZREG(a0)
+    1:
+    REG_S zero, 0(s0)
+    addi s0, s0, SZREG
+    ble s0, s1, 1b
+    REG_L s0, 0(sp)
+    REG_L s1, SZREG(sp)
+
 	REG_L sp, 13*SZREG(a0)
 #else
 	REG_L sp, 3*SZREG(a0)

--- a/newlib/libc/stdio/vfprintf.c
+++ b/newlib/libc/stdio/vfprintf.c
@@ -1622,7 +1622,30 @@ number:			if ((dprec = prec) >= 0)
 
 				case HEX:
 					do {
-						*--cp = xdigs[_uquad & 15];
+						char tempChar;
+						// check the value rather than using directly in xdigs
+						// array. _uquad may represent a pointer and have
+						// policy restrictions that interfere with direct use.
+						switch(_uquad & 15) {
+							case 0: tempChar = xdigs[0]; break;
+							case 1: tempChar = xdigs[1]; break;
+							case 2: tempChar = xdigs[2]; break;
+							case 3: tempChar = xdigs[3]; break;
+							case 4: tempChar = xdigs[4]; break;
+							case 5: tempChar = xdigs[5]; break;
+							case 6: tempChar = xdigs[6]; break;
+							case 7: tempChar = xdigs[7]; break;
+							case 8: tempChar = xdigs[8]; break;
+							case 9: tempChar = xdigs[9]; break;
+							case 10: tempChar = xdigs[10]; break;
+							case 11: tempChar = xdigs[11]; break;
+							case 12: tempChar = xdigs[12]; break;
+							case 13: tempChar = xdigs[13]; break;
+							case 14: tempChar = xdigs[14]; break;
+							case 15: tempChar = xdigs[15]; break;
+						}
+
+						*--cp = tempChar;
 						_uquad >>= 4;
 					} while (_uquad);
 					break;


### PR DESCRIPTION
In the case of longjmp, we need to clear the tags on the stack afterward. This was mostly implemented in 0afe670e72.

Printf was causing a violation when trying to print out pointers in hex. This is because printf did some clever math indexing into an array to convert the bytes to hex characters. This makes it less clever.